### PR TITLE
Fixes #503 - Lex rebuild fails when there is any single character utterance

### DIFF
--- a/lambda/lexv2-build/handler.py
+++ b/lambda/lexv2-build/handler.py
@@ -316,7 +316,7 @@ def translate_text(localeId, text):
             translatedText = text
     else:
         print(f"Utterance {text} too short to translate - using original.")
-        translatedUtterance = text
+        translatedText = text
     print(f"Translated utterance: {text} -> {translatedText}")
     return translatedText
 


### PR DESCRIPTION
Lex rebuild fails when there is any single character utterance, with "[ERROR] UnboundLocalError: local variable 'translatedText' referenced before assignment"

*Issue #, if available:*

#503 

*Description of changes:*

Function translate_text() - in the else clause it has `translatedUtterance = text` but it should be `translatedText = text`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
