### PR TITLE
fixes #506 - bot prompts 'What is the question?' when using ElicitResponse

### DIFF
--- a/lambda/fulfillment/lib/middleware/lex.js
+++ b/lambda/fulfillment/lib/middleware/lex.js
@@ -28,7 +28,18 @@ function isConnectClientChat(req){
 }
 
 function isElicitResponse(request, response){
-    return _.get(response,'result.elicitResponse.responsebot_hook', undefined) !== undefined || _.get(request,'session.qnabotcontext.specialtyBot' ,undefined) !== undefined;
+    let result = false;
+    const qnabotcontextJSON = _.get(response,'session.qnabotcontext');
+    if (qnabotcontextJSON) {
+        const qnabotcontext = JSON.parse(qnabotcontextJSON);
+        if (_.get(qnabotcontext,'elicitResponse.responsebot')) {
+            result = true;
+        }
+        if (_.get(qnabotcontext,'specialtyBot')) {
+            result = true;
+        }
+    }
+    return result;
 }
 
 function trapIgnoreWords(req, transcript) {
@@ -395,9 +406,7 @@ function getV2ElicitTemplate(request, response){
         sessionState: {
             sessionAttributes:_.get(response,'session',{}),
             dialogAction:{
-                type:'ElicitSlot',
-                slotToElicit: 'qnaslot'
-            },
+                type:'ElicitIntent'            },
             intent: {
                 name: 'QnaIntent',
             },


### PR DESCRIPTION
*Issue #, if available:*
#506 

*Description of changes:*

(1) Modify check for isElicitResponse to provide more robust detection of responsebot enablement using qnabotcontext session attribute. Previous mothod relied on response.result object which was not present during responsebot slot prompting. 

(2) Modify lex response to use DialogAction `ElicitIntent` instead of `ElicitSlot` when a responsebot is enabled. 

The problem reported in #506 is related to the fact that when response bots were active QnABot returned lex reponse `ElicitSlot` with `SlotToElicit` set to `qnaslot`, instead of the default intent 'Fullfilled' response. This was done to support Connect integration to avoid the flow leaving the GetCustomerInput block during ElicitResponse interactions.   
This used to work, possibly because of several factors including (i) the qnaslot slot used to have significantly more sample values (default utterances) that we removed in v5.2.0, since these frequently cause customer confusion are should (in theory) be no longer necessary since adding FALLBACK intent support. (ii) updated models in Lex are stricter in confidence threshold when utterance doesn't resemble a trained slottype value. 
By using DialogAction `ElicitIntent` instead, we achieve the same bahavior for Connect integration, but avoid explictly forcing Lex to try to fill the qnaslot, allowing it instead to match the FALLBACK intent on the main bot and allowing the users response to sucessfully pass through to the ELicitResponse bot.

I tested it with both Web UI, and with Connect to make sure the chaining demo worked in both cases without problematic prompting.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
