### PR TITLE
Add parm to support passing token auth to Kendra Index.

### DIFF
--- a/lambda/es-proxy-layer/lib/kendra.js
+++ b/lambda/es-proxy-layer/lib/kendra.js
@@ -330,6 +330,17 @@ async function routeKendraRequest(event, context) {
         && origQuestion && question && origQuestion!=question;
     qnabot.log("useOriginalLanguageQuery: " + useOriginalLanguageQuery);
 
+    // Add support for passing token based authentication to Kendra.  Note useKendraTokenAuth returns as a boolean value and isVerifiedIdentity a string.    
+    let useKendraTokenAuth = event.req["_settings"]["ALT_SEARCH_KENDRA_INDEXES_TOKEN_AUTH"] ? event.req["_settings"]["ALT_SEARCH_KENDRA_INDEXES_TOKEN_AUTH"] : false;
+    var isVerifiedIdentity = _.get(event.req["_userInfo"], "isVerifiedIdentity");
+    if (useKendraTokenAuth === true && isVerifiedIdentity === "true"){
+        qnabot.log(`PASSING TOKEN AUTH TO KENDRA:: isVerifiedIdentity: ${isVerifiedIdentity} and ALT_SEARCH_KENDRA_INDEXES_TOKEN_AUTH: ${useKendraTokenAuth}`);
+        var idtokenjwt = _.get(event.req["session"], "idtokenjwt");
+        var usrContext = {"Token" : idtokenjwt};
+    } else {
+        qnabot.log(`NOT PASSING TOKEN AUTH TO KENDRA:: isVerifiedIdentity: ${isVerifiedIdentity} and  ALT_SEARCH_KENDRA_INDEXES_TOKEN_AUTH: ${useKendraTokenAuth}`);
+    }
+
     // This function can handle configuration with an array of kendraIndexes.
     // Iterate through this area and perform queries against Kendra.
     kendraIndexes.forEach(function (index, i) {
@@ -351,6 +362,13 @@ async function routeKendraRequest(event, context) {
             IndexId: index, /* required */
             QueryText: useOriginalLanguageQuery ? origQuestion: question, /* required */
         };
+
+        // if ALT_SEARCH_KENDRA_INDEXES_TOKEN_AUTH===true && isVerifiedIdentity==="true", then pass the idtoken via UserContext to Kendra query params.
+        if (usrContext){
+            qnabot.log("Updating Kendra query params to include UserContext.");
+            params.UserContext = usrContext
+        }
+        
         let kendraQueryArgs = _.get(event.req, "kendraQueryArgs", [])
         qnabot.log(`Kendra query args: ${kendraQueryArgs}`)
         for (let argString of kendraQueryArgs) {


### PR DESCRIPTION
*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

The purpose of this change is to allow QnABot to be configured to pass an OpenID JWT to Kendra Index(es).  It is controlled by the new configuration setting "ALT_SEARCH_KENDRA_INDEXES_TOKEN_AUTH" which defaults to "false".  If "ALT_SEARCH_KENDRA_INDEXES_TOKEN_AUTH" is set to "true" and "_userInfo.isVerfiedIdentity" is "true", then QnABot will pass the idtoken with the each Kendra Index query configured for fallback (i.e. ALT_SEARCH_KENDRA_INDEXES).

The changes have been made to the es-proxy-layer within the kendra.js file.

The Settings that are in play:
* ENFORCE_VERIFIED_IDENTITY                = false (false allows for unauthenticated user as well as authenticated.)
* IDENTITY_PROVIDER_JWKS_URLS          = (set to appropriate cognito user pool)
* ALT_SEARCH_KENDRA_INDEXES            = (set to one Kendra Index)
* ALT_SEARCH_KENDRA_INDEXES_TOKEN_AUTH = false / true (false is default. true allows QnABot to send idtoken to Kendra)

Some notes about the 8 Use Cases:
* CASE 1 through 4: User is NOT authenticted within Lex-Web-UI.
* CASE 5 through 8: User is authenticated within Lex-Web-UI.
* CASES 1,2 and 5,6 have Kendra Auth Enabled.  Cases 3,4 and 7,8 have Kendra Auth Disabled.


The following 8 Use Cases have been explored:
* CASE 1: Kendra Index has Auth Enabled. isVerifiedIdentity === "false". ALT_SEARCH_KENDRA_INDEXES_TOKEN_AUTH === false.
    * User is NOT authenticated. Has no token to send to Kendra.
    * QnABot is NOT configured to send a token and user has NO token to send.  NO token is sent.
    * Kendra Index has auth enabled, but does not require a token to be sent.  
    * User will only get public content (not protected by ACLs).

* CASE 2: Kendra Index has Auth Enabled. isVerifiedIdentity === "false". ALT_SEARCH_KENDRA_INDEXES_TOKEN_AUTH === true. 
    * User is NOT authenticated. Has no token to send to Kendra.
    * QnABot is configured to send a token but user has NO token to send.  NO token is sent.
    * Kendra Index has auth enabled, but does not require a token to be sent.  
    * User will only get public content (not protected by ACLs).

* CASE 3: Kendra Index has Auth Disabled. isVerifiedIdentity === "false". ALT_SEARCH_KENDRA_INDEXES_TOKEN_AUTH === false.
    * User is NOT authenticated. Has no token to send to Kendra.
    * QnABot is NOT configured to send a token and user has NO token to send.  NO token is sent.
    * Kendra Index has auth disabled.  Any Kendra Source ACLs are ignored.
    * User will get ALL content from the index since source ACLs are ignored.

* CASE 4: Kendra Index has Auth Disabled. isVerifiedIdentity === "false". ALT_SEARCH_KENDRA_INDEXES_TOKEN_AUTH === true.
    * User is NOT authenticated. Has no token to send to Kendra.
    * QnABot is configured to send a token but user has NO token to send.  NO token is sent.
    * Kendra Index has auth disabled.  Any Kendra Source ACLs are ignored.
    * User will get ALL content from the index since source ACLs are ignored.

* CASE 5: Kendra Index has Auth Enabled. isVerifiedIdentity === true. ALT_SEARCH_KENDRA_INDEXES_TOKEN_AUTH === false.
    * User is authenticated. User has a token to send to Kendra.
    * QnABot is NOT configured to send a token even though user has a token to send.  NO token is sent.
    * Kendra Index has auth enabled, but does not require a token to be sent.  
    * User will only get content not protected by ACLs.

* CASE 6: Kendra Index has Auth Enabled. isVerifiedIdentity === "true". ALT_SEARCH_KENDRA_INDEXES_TOKEN_AUTH === true.
    * User is authenticated. User has a token to send to Kendra.
    * QnABot is configured to send a token and user has a token to send.  An idtoken is sent to Kendra Index query.
    * Kendra Index has auth enabled, but does not require a token to be sent.  
    * User will only get public and private content based on their entitlements as protected by ACLs.

* CASE 7: Kendra Index has Auth Disabled. isVerifiedIdentity === true. ALT_SEARCH_KENDRA_INDEXES_TOKEN_AUTH === false.
    * User is authenticated. User has a token to send to Kendra.
    * QnABot is NOT configured to send a token even though user has a token to send.  NO token is sent.
    * Kendra Index has auth disabled.  Any Kendra Source ACLs are ignored.
    * User will get ALL content from the index since source ACLs are ignored.

* CASE 8: Kendra Index has Auth Disabled. isVerifiedIdentity === "true". ALT_SEARCH_KENDRA_INDEXES_TOKEN_AUTH === true.
    * User is authenticated. User has a token to send to Kendra.
    * QnABot is configured to send a token and user has a token to send.  An idtoken is sent to Kendra Index query.
    * Kendra Index has auth disabled.  Any Kendra Source ACLs are ignored.
    * User will get no response as Kendra exception is thrown.

