### PR TITLE
Fix for case sensitivity on clientFilterValues

### DIFF
--- a/lambda/es-proxy-layer/lib/esbodybuilder.js
+++ b/lambda/es-proxy-layer/lib/esbodybuilder.js
@@ -80,7 +80,10 @@ function build_query(params) {
           },
           {
             "term": {
-              "clientFilterValues": qnaClientFilter
+              "clientFilterValues": {
+                "value": qnaClientFilter,
+                "case_insensitive": true
+              }
             }
           }
         ]


### PR DESCRIPTION
*#518*

*Description of changes:*

Added the `case_insensitive` attribute to the `clientFitlerValue` term query as a fix for the issue above.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
