### PR TITLE
Configurable ES EBS Volume Size

### DIFF
--- a/templates/master/elasticsearch/es.js
+++ b/templates/master/elasticsearch/es.js
@@ -10,7 +10,7 @@ var properties={
     },
     "EBSOptions": {
        "EBSEnabled": true,
-       "VolumeSize": 10,
+       "VolumeSize": {"Ref":"ElasticSearchEBSVolumeSize"},
        "VolumeType": "gp2"
     },
     "EngineVersion": "OpenSearch_1.3",

--- a/templates/master/index.js
+++ b/templates/master/index.js
@@ -216,6 +216,11 @@ module.exports={
         "AllowedValues" : ["1", "2", "4"],
         "Default":"4"
     },
+    "ElasticSearchEBSVolumeSize":{
+        "Type":"Number",
+        "Description":"Size in GB of each EBS volume attached to OpenSearch node instances - '10' is the minimum default volume size.",
+        "Default":10
+    },
     "FulfillmentConcurrency": {
       "Type":"Number",
       "Description":"The amount of provisioned concurrency for the fulfillment Lambda function",

--- a/templates/public-vpc-support/index.js
+++ b/templates/public-vpc-support/index.js
@@ -44,6 +44,7 @@ module.exports=Promise.resolve(require('../master')).then(function(base){
         "InstallLexResponseBots",
         "FulfillmentConcurrency",
         "ElasticSearchNodeCount",
+        "ElasticSearchEBSVolumeSize",
         "KibanaDashboardRetentionMinutes",
         "VPCSubnetIdList",
         "VPCSecurityGroupIdList",
@@ -90,6 +91,7 @@ module.exports=Promise.resolve(require('../master')).then(function(base){
                    },
                    "Parameters": [
                         "ElasticSearchNodeCount",
+                        "ElasticSearchEBSVolumeSize",
                         "Encryption",
                         "KibanaDashboardRetentionMinutes"
                    ]

--- a/templates/public/index.js
+++ b/templates/public/index.js
@@ -39,6 +39,7 @@ module.exports=Promise.resolve(require('../master')).then(function(base){
         "DefaultKendraIndexId",
         "Encryption",
         "ElasticSearchNodeCount",
+        "ElasticSearchEBSVolumeSize",
         "KibanaDashboardRetentionMinutes",
         "PublicOrPrivate",
         "LexV2BotLocaleIds",
@@ -79,6 +80,7 @@ module.exports=Promise.resolve(require('../master')).then(function(base){
                    },
                    "Parameters": [
                         "ElasticSearchNodeCount",
+                        "ElasticSearchEBSVolumeSize",
                         "Encryption",
                         "KibanaDashboardRetentionMinutes"
                    ]


### PR DESCRIPTION
*Description of changes:*

This change allows the EBS Volume size to be updated via template parameter. It goes hand in hand with the Kibana Retention Period parameter. If you increase the retention period, most likely need to increase the volume size as well. Rather than having the user figure out how to do this via CLI, API, or Console, its much easier to allow this as a template parameter. Customers that like to deploy via devops mechanisms would much prefer this to be specified as a template parameter. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
