### PR TITLE
Add MetricsBucket to stack outputs such that it can be used downstream in other pipeline deployments.

### DIFF
--- a/templates/master/index.js
+++ b/templates/master/index.js
@@ -155,7 +155,10 @@ module.exports={
     },
     "FeedbackSNSTopic": {
         "Value":{"Fn::GetAtt": ["ExamplesStack", "Outputs.FeedbackSNSTopic"]}
-    }
+    },
+    "MetricsBucket": {
+        "Value":{"Ref":"MetricsBucket"}
+      }
   },
   "Parameters": {
     "ElasticsearchName":{

--- a/templates/public-vpc-support/index.js
+++ b/templates/public-vpc-support/index.js
@@ -31,7 +31,8 @@ module.exports=Promise.resolve(require('../master')).then(function(base){
         "FeedbackSNSTopic",
         "ESProxyLambda",
         "ElasticsearchEndpoint",
-        "ElasticsearchIndex"
+        "ElasticsearchIndex",
+        "MetricsBucket"
     ])
     base.Parameters=_.pick(base.Parameters,[
         "Email",

--- a/templates/public/index.js
+++ b/templates/public/index.js
@@ -31,7 +31,8 @@ module.exports=Promise.resolve(require('../master')).then(function(base){
         "FeedbackSNSTopic",
         "ESProxyLambda",
         "ElasticsearchEndpoint",
-        "ElasticsearchIndex"
+        "ElasticsearchIndex",
+        "MetricsBucket"
     ])
     base.Parameters=_.pick(base.Parameters,[
         "Email",


### PR DESCRIPTION
Customers want to create data transformations on QnABot metrics data specifically to flatten data for use by Athena queries for display in Tableau or Quicksight. Adding this to the set of stack Outputs, allows terraform and other deployment mechanisms to have access to the name of the bucket which can be the source of data transformations.

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
