### PR TITLE
change description of event format to the actual format used.

### DIFF
--- a/docs/semantic_matching_using_LLM_embeddings/README.md
+++ b/docs/semantic_matching_using_LLM_embeddings/README.md
@@ -45,8 +45,8 @@ Use a custom Lambda function to use any Embedding API or embedding model on Sage
 Your Lambda function is passed an event of the form:
 ```
 {
-  "inputtype": "string", // value 'q' for question, 'a' for answer
-  "inputtext":"string"   // string of question of answer to use to generate embeddings 
+  "inputType": "string", // value 'q' for question, 'a' for answer
+  "inputText":"string"   // string of question of answer to use to generate embeddings 
 }
 ```
 and must return a JSON structure of the form:


### PR DESCRIPTION
Fix README.md documentation error in docs/semantic_matching_using_LLM_embeddings/README.ms which contains and invalid event definition.

*Description of changes:*

Change "inputtype" to "inputType"
Change "inputtext" to "inputText"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
