### PR TITLE
Optional userinfo ttl

### DIFF
--- a/lambda/fulfillment/lib/middleware/2_preprocess.js
+++ b/lambda/fulfillment/lib/middleware/2_preprocess.js
@@ -220,7 +220,7 @@ module.exports = async function preprocess(req, res) {
     // Add _userInfo to res, with updated timestamps
     // May be further modified by lambda hooks
     // Will be saved back to DynamoDB in userInfo.js
-    const ttlDays = _.get(req, '_settings.DYNAMODB_TTL_DAYS', 0)
+    const ttlDays = _.get(req, '_settings.USERINFO_TTL_DAYS', 0)
     const res_userInfo = await update_userInfo(userId, req_userInfo, ttlDays);
     _.set(res, '_userInfo', res_userInfo);
 

--- a/templates/master/default-settings.js
+++ b/templates/master/default-settings.js
@@ -109,6 +109,7 @@ const default_settings = {
     LLM_QA_NO_HITS_REGEX:
         'Sorry,  //remove comment to enable custom no match (no_hits) when LLM does not know the answer.',
     LLM_PROMPT_MAX_TOKEN_LIMIT: '${LLM_PROMPT_MAX_TOKEN_LIMIT}',
+    DYNAMODB_TTL_DAYS: 0, // Set to 0 to disable setting a ttl property in DyanmoDB
 };
 
 const defaultGenerateQueryPromptTemplate =

--- a/templates/master/default-settings.js
+++ b/templates/master/default-settings.js
@@ -109,7 +109,7 @@ const default_settings = {
     LLM_QA_NO_HITS_REGEX:
         'Sorry,  //remove comment to enable custom no match (no_hits) when LLM does not know the answer.',
     LLM_PROMPT_MAX_TOKEN_LIMIT: '${LLM_PROMPT_MAX_TOKEN_LIMIT}',
-    DYNAMODB_TTL_DAYS: 0, // Set to 0 to disable setting a ttl property in DyanmoDB
+    USERINFO_TTL_DAYS: 0, // Set to 0 to disable setting a ttl property in DyanmoDB
 };
 
 const defaultGenerateQueryPromptTemplate =

--- a/templates/master/dynamodb/index.js
+++ b/templates/master/dynamodb/index.js
@@ -33,6 +33,10 @@ module.exports = {
                     KeyType: 'HASH',
                 },
             ],
+            TimeToLiveSpecification: {
+                AttributeName: "ttl",
+                Enabled: true
+            },
         },
         Metadata: util.cfnNag(['W74']),
     },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds the ability to set a TTL on records added to the DynamoDB UsersTable by adding:

* a TimeToLiveSpecification to the UserTable setting the TTL field to ttl
* a setting called USERINFO_TTL_DAYS
* functionality to the fulfillment lambda which causes it to set an appropriate ttl on user cache records every time a new interaction occurs, IF the USERINFO_TTL_DAYS setting is greater than zero

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
