### PR TITLE
Improve merging of chained items

### DIFF
--- a/source/lambda/es-proxy-layer/lib/fulfillment-event/mergeNext.js
+++ b/source/lambda/es-proxy-layer/lib/fulfillment-event/mergeNext.js
@@ -11,7 +11,7 @@ function mergeMarkdown(hit1, hit2) {
     const md1 = _.get(hit1, 'alt.markdown');
     let md1_to_merge = hit1.a
     if (md1) {
-        md1_to_merge = md1
+        md1_to_merge = md1.replace(/^[ \t]+/, '').replace(/[ \t]+$/, '')
     }
     qnabot.debug('markdown from first hit:', md1_to_merge)
 
@@ -19,7 +19,7 @@ function mergeMarkdown(hit1, hit2) {
     const md2 = _.get(hit2, 'alt.markdown');
     let md2_to_merge = hit2.a
     if (md2) {
-        md2_to_merge = md2
+        md2_to_merge = md2.replace(/^[ \t]+/, '').replace(/[ \t]+$/, '')
     }
     qnabot.debug('markdown from second hit:', md2_to_merge)
 
@@ -40,7 +40,7 @@ function mergeSSML(hit1, hit2) {
     if (ssml1) {
         // strip <speak> tags
         qnabot.debug('SSML from first hit:', ssml1)
-        ssml1_to_merge = ssml1.replace(/<speak>|<\/speak>/g, '');
+        ssml1_to_merge = ssml1.replace(/<speak>|<\/speak>/g, '').trim();
     }
 
     // get SSML from second item
@@ -49,7 +49,7 @@ function mergeSSML(hit1, hit2) {
     if (ssml2) {
         // strip <speak> tags
         qnabot.debug('SSML from second hit:', ssml2)
-        ssml2_to_merge = ssml2.replace(/<speak>|<\/speak>/g, '');
+        ssml2_to_merge = ssml2.replace(/<speak>|<\/speak>/g, '').trim();
     }
 
     // merge SSML, if present in either item

--- a/source/lambda/es-proxy-layer/lib/fulfillment-event/mergeNext.js
+++ b/source/lambda/es-proxy-layer/lib/fulfillment-event/mergeNext.js
@@ -6,35 +6,78 @@
 const _ = require('lodash');
 const qnabot = require('qnabot/logging');
 
+function mergeMarkdown(hit1, hit2) {
+    // get markdown from first item
+    const md1 = _.get(hit1, 'alt.markdown');
+    let md1_to_merge = hit1.a
+    if (md1) {
+        md1_to_merge = md1
+    }
+    qnabot.debug('markdown from first hit:', md1_to_merge)
+
+    // get markdown from second item
+    const md2 = _.get(hit2, 'alt.markdown');
+    let md2_to_merge = hit2.a
+    if (md2) {
+        md2_to_merge = md2
+    }
+    qnabot.debug('markdown from second hit:', md2_to_merge)
+
+    // merge markdown, if present in either item
+    if (md1 || md2) {
+        const md_merged = `${md1_to_merge}\n${md2_to_merge}`
+        qnabot.debug('Merged markdown:', md_merged)
+        _.set(hit2, 'alt.markdown', md_merged);
+    } else {
+        qnabot.debug('Markdown field missing from both items. Skipping markdown merge');
+    }
+}
+
+function mergeSSML(hit1, hit2) {
+    // get SSML from first item
+    const ssml1 = _.get(hit1, 'alt.ssml');
+    let ssml1_to_merge = hit1.a
+    if (ssml1) {
+        // strip <speak> tags
+        qnabot.debug('SSML from first hit:', ssml1)
+        ssml1_to_merge = ssml1.replace(/<speak>|<\/speak>/g, '');
+    }
+
+    // get SSML from second item
+    const ssml2 = _.get(hit2, 'alt.ssml');
+    let ssml2_to_merge = hit2.a
+    if (ssml2) {
+        // strip <speak> tags
+        qnabot.debug('SSML from second hit:', ssml2)
+        ssml2_to_merge = ssml2.replace(/<speak>|<\/speak>/g, '');
+    }
+
+    // merge SSML, if present in either item
+    if (ssml1 || ssml2) {
+        // concatenate, and re-wrap with <speak> tags
+        const ssml_merged = `<speak>${ssml1_to_merge} ${ssml2_to_merge}</speak>`
+        qnabot.debug('Merged SSML:', ssml_merged)
+        _.set(hit2, 'alt.ssml', ssml_merged);
+    } else {
+        qnabot.debug('SSML field missing from both items. Skipping SSML merge');
+    }
+}
+
 function mergeNext(hit1, hit2) {
     if (hit1 === undefined) {
         return hit2;
     }
     qnabot.debug('Merge chained items');
+
+    // merge alternate answers
+    mergeMarkdown(hit1, hit2)
+    mergeSSML(hit1, hit2)
+
     // merge plaintext answer
     if (hit1 && hit1.a) {
         hit2.a = hit1.a.trim() + ' ' + hit2.a.trim();
     }
-    // merge markdown, if present in both items
-    const md1 = _.get(hit1, 'alt.markdown');
-    const md2 = _.get(hit2, 'alt.markdown');
-    if (md1 && md2) {
-        _.set(hit2, 'alt.markdown', `${md1}\n${md2}`);
-    } else {
-        qnabot.debug('Markdown field missing from one or both items; skip markdown merge');
-    }
-    // merge SSML, if present in both items
-    let ssml1 = _.get(hit1, 'alt.ssml');
-    let ssml2 = _.get(hit2, 'alt.ssml');
-    if (ssml1 && ssml2) {
-        // strip <speak> tags
-        ssml1 = ssml1.replace(/<speak>|<\/speak>/g, '');
-        ssml2 = ssml2.replace(/<speak>|<\/speak>/g, '');
-        // concatenate, and re-wrap with <speak> tags
-        _.set(hit2, 'alt.ssml', `<speak>${ssml1} ${ssml2}</speak>`);
-    } else {
-        qnabot.debug('SSML field missing from one or both items; skip SSML merge');
-    }
+
     // build arrays of Lambda Hooks and arguments
     let lambdahooks = _.get(hit1, 'lambdahooks', []);
     // if hits1 doesn't have a lambdahooks field (no previous merge), then initialize using 'l' and 'args' from hit 1

--- a/source/lambda/es-proxy-layer/lib/fulfillment-event/mergeNext.js
+++ b/source/lambda/es-proxy-layer/lib/fulfillment-event/mergeNext.js
@@ -13,7 +13,7 @@ function mergeNext(hit1, hit2) {
     qnabot.debug('Merge chained items');
     // merge plaintext answer
     if (hit1 && hit1.a) {
-        hit2.a = hit1.a + hit2.a;
+        hit2.a = hit1.a.trim() + ' ' + hit2.a.trim();
     }
     // merge markdown, if present in both items
     const md1 = _.get(hit1, 'alt.markdown');

--- a/source/lambda/es-proxy-layer/test/fulfillment-event/mergeNext.test.js
+++ b/source/lambda/es-proxy-layer/test/fulfillment-event/mergeNext.test.js
@@ -1,0 +1,146 @@
+/** ************************************************************************************************
+*   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.                             *
+*   SPDX-License-Identifier: Apache-2.0                                                            *
+ ************************************************************************************************ */
+
+const _ = require('lodash');
+const { mergeNext } = require('../../lib/fulfillment-event/mergeNext');
+
+jest.mock('qnabot/settings');
+jest.mock('qnabot/logging');
+
+describe('mergeNext', () => {
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('merges hits', async () => {
+    const hit1 = {
+      a: 'start',
+      alt: {
+        markdown: '#start',
+        ssml: '<speak>start</speak>',
+      },
+    };
+    const hit2 = {
+      a: 'end',
+      alt: {
+        markdown: '#end',
+        ssml: '<speak>end</speak>',
+      },
+    }
+    result = mergeNext(hit1, hit2)
+
+    expect(result.a).toStrictEqual('start end')
+    expect(result.alt.markdown).toStrictEqual('#start\n#end')
+    expect(result.alt.ssml).toStrictEqual('<speak>start end</speak>')
+  });
+
+  test('merges hits and trims whitespace', async () => {
+    const hit1 = {
+      a: '  start  ',
+      alt: {
+        markdown: '  #start  ',
+        ssml: '  <speak>  start  </speak>  ',
+      },
+    };
+    const hit2 = {
+      a: '  end  ',
+      alt: {
+        markdown: '  #end  ',
+        ssml: '  <speak>  end  </speak>  ',
+      },
+    }
+    result = mergeNext(hit1, hit2)
+
+    expect(result.a).toStrictEqual('start end')
+    expect(result.alt.markdown).toStrictEqual('#start\n#end')
+    expect(result.alt.ssml).toStrictEqual('<speak>start end</speak>')
+  });
+
+
+  test('merges ssml in the first hit', async () => {
+    const hit1 = {
+      a: 'start',
+      alt: {
+        ssml: '<speak>start</speak>',
+      },
+    };
+    const hit2 = {
+      a: 'end',
+    }
+    result = mergeNext(hit1, hit2)
+
+    expect(result.a).toStrictEqual('start end')
+    expect(result.alt.ssml).toStrictEqual('<speak>start end</speak>')
+  });
+
+  test('merges ssml in the second hit', async () => {
+    const hit1 = {
+      a: 'start',
+    };
+    const hit2 = {
+      a: 'end',
+      alt: {
+        ssml: '<speak>end</speak>',
+      },
+    }
+    result = mergeNext(hit1, hit2)
+
+    expect(result.a).toStrictEqual('start end')
+    expect(result.alt.ssml).toStrictEqual('<speak>start end</speak>')
+  });
+
+  test('merges markdown in the first hit', async () => {
+    const hit1 = {
+      a: 'start',
+      alt: {
+        markdown: '#start',
+      },
+    };
+    const hit2 = {
+      a: 'end',
+    }
+    result = mergeNext(hit1, hit2)
+
+    expect(result.a).toStrictEqual('start end')
+    expect(result.alt.markdown).toStrictEqual('#start\nend')
+  });
+
+  test('merges markdown in the second hit', async () => {
+    const hit1 = {
+      a: 'start',
+    };
+    const hit2 = {
+      a: 'end',
+      alt: {
+        markdown: '#end',
+      },
+    }
+    result = mergeNext(hit1, hit2)
+
+    expect(result.a).toStrictEqual('start end')
+    expect(result.alt.markdown).toStrictEqual('start\n#end')
+  });
+
+  test('merges markdown and preserves newlines', async () => {
+    const hit1 = {
+      a: 'start',
+      alt: {
+        markdown: '\n#start\n',
+      },
+    };
+    const hit2 = {
+      a: 'end',
+      alt: {
+        markdown: '\n#end\n',
+      },
+    }
+    result = mergeNext(hit1, hit2)
+
+    expect(result.a).toStrictEqual('start end')
+    expect(result.alt.markdown).toStrictEqual('\n#start\n\n\n#end\n')
+  });
+
+});

--- a/source/templates/examples/examples/responsebots-lexv2.js
+++ b/source/templates/examples/examples/responsebots-lexv2.js
@@ -117,7 +117,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },
@@ -242,7 +242,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },
@@ -362,7 +362,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },
@@ -469,7 +469,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },
@@ -600,7 +600,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },
@@ -746,7 +746,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },
@@ -858,7 +858,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },
@@ -958,7 +958,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },
@@ -1126,7 +1126,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },
@@ -1319,7 +1319,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },
@@ -1499,7 +1499,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },
@@ -1607,7 +1607,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },
@@ -1702,7 +1702,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },
@@ -1818,7 +1818,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },
@@ -1921,7 +1921,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },
@@ -2029,7 +2029,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },
@@ -2124,7 +2124,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },
@@ -2233,7 +2233,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },
@@ -2340,7 +2340,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },
@@ -2452,7 +2452,7 @@ exports.resources = {
                     IntentClosingSetting: {
                         ClosingResponse: {
                             MessageGroupsList: [{
-                                Message: { PlainTextMessage: { Value: 'OK. ' } },
+                                Message: { PlainTextMessage: { Value: 'OK.' } },
                             }],
                         },
                     },


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Add a space between merged items
- Whitespace returned by ResponseBots is no longer required
- Enable chaining of plaintext and SSML items while maintaining SSML content
- Enable chaining of plaintext and Markdown items while maintaining Markdown content
- Honor SSML returned from ResponseBots

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
