### PR TITLE
Prevent loop when using slots and chaining

### DIFF
--- a/lambda/es-proxy-layer/lib/fulfillment-event/evaluateConditionalChaining.js
+++ b/lambda/es-proxy-layer/lib/fulfillment-event/evaluateConditionalChaining.js
@@ -96,11 +96,17 @@ async function evaluateConditionalChaining(req, res, hit, conditionalChaining) {
     }
     qnabot.log('Chained document rule evaluated to:', next_q);
 
+    // Remove qid if set by slots - this would override the chained item
+    if(req.hasOwnProperty('qid')) {
+        delete req['qid'];
+    }
+
     let hit2;
     if (next_q) {
         req.question = next_q;
         [req, res, hit2, errors] = await getHit(req, res);
     }
+
     // if the question we are chaining to, also has conditional chaining, be sure to navigate set up
     // next user input to elicitResponse from this lex Bot.
     if (hit2) {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* When chaining items, if the first item in the chain contains slots, the response will contain 11 copies of the first answer, and never append the answer from the chained item. This PR fixes that issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
