### PR TITLE
Tioth dev specialty bot routing 2024 b

### DIFF
--- a/lambda/es-proxy-layer/lib/handlebars.js
+++ b/lambda/es-proxy-layer/lib/handlebars.js
@@ -308,7 +308,10 @@ async function handleSsml(ssml, hit_out, context) {
     try {
         const text = await handleSignS3(ssml);
         const ssml_template = Handlebars.compile(text);
-        hit_out.alt.ssml = ssml_template(context);
+        // Make sure any \n newlines in the template response are removed as Lex will not handle producing a valid
+        // audio response if embedded newlines creep into the output from the template. The ssml_template may be
+        // organized with new lines to allow easier editing and understanding in the Designer UI.
+        hit_out.alt.ssml = ssml_template(context).replaceAll("\n","");
         if (autotranslate) {
             _.set(hit_out, 'autotranslate.alt.ssml', true);
         }

--- a/lambda/fulfillment/lib/middleware/lex.js
+++ b/lambda/fulfillment/lib/middleware/lex.js
@@ -426,8 +426,9 @@ function getV2ElicitTemplate(request, response) {
             dialogAction: { type: 'ElicitIntent' },
             intent: {
                 name: 'QnaIntent',
+                state: 'InProgress',
+                slots: _.mapValues(_.get(response, 'slots'), (value) => ((value) ? { value: { interpretedValue: value } } : null)),
             },
-            state: 'InProgress',
         },
         messages: [
             {
@@ -449,9 +450,9 @@ function getV2DialogCodeHookResponseTemplate(request, response) {
             },
             intent: {
                 name: response.intentname,
+                state: (nextSlot) ? 'InProgress' : 'ReadyForFulfillment',
                 slots: _.mapValues(_.get(response, 'slots'), (value) => ((value) ? { value: { interpretedValue: value } } : null)),
             },
-            state: (nextSlot) ? 'InProgress' : 'ReadyForFulfillment',
         },
     };
 }


### PR DESCRIPTION
Issue #, if available: 674

Description of changes:

A couple of fixes are addressed in this pull request. 

a) fix LexV2 lambda return templates (lambda/fulfillment/lib/middleware/lex.js) for elicitIntent (getV2ElicitTemplate) dialogCodeHook (getV2DialogCodeHookResponseTemplate) to return state and slots as part of intent structure. 

b) fix processing of SSML in handlebars.js (lambda/es-proxy-layer/lib/handlebars.js) such that new lines (\n) are not injected as part of template processing. Designer UI allows the creation of a response for SSML using handlebar syntax where new lines are allowed in the template and cause handlebars to inject a "\n" in the response which causes Lex V2 to return an invalid audio/ogg stream. 

c) Integrate original lexv2 bug fixes from first PR for speciltyBotRouter.js and implement additional fixes as necessary. Address the following merge and feature issues:

    specialtyBotRouter.js will throw an exception as LexV2 will sometimes not return an intent as expected at lexv2response.sessionState.intent. The revised code is not handling this condition.

    specialtyBotRouter.js will throw an exception in getDialogState() for the same undefined lexv2response.sessionState.intent.

    bot router termination is not preserving the last message from the specialty bot in endUseOfSpecialtyBot().
    
    both markdown and ssml responses from a target qnabot (specialtyBot) are merged into the the botRouter response. 

    merging of specialty bot session attributes for supervisory bot response does not handle special cases for "appContext" and "qnabotcontext" when the specialty bot is another QnaBot.

    The matching QID's answer/markdown which initiated bot routing is not provided to the user. The original answer is ignored when it should be prepended as part the response message when bot routing starts.

    The superivsory bot does not terminate bot routing when the specialty LexV2 bot reaches fulfillment or is closed. Incorrect states are being checked. Note that a specialty QnABot (also LexV2) target is a special case where bot routing should not be terminated when fulfillment is reached as each answer represents a fulfilled state. A specialty QnABot requires special processing to terminate bot routing either through a defined session attribute or by the user entering the termination phrase.

    getRespCard() is incorrectly defining several attributes that should be left undefined. One example is an image url in the response card. When an image url is defined in the response card as an empty string which the present code is setting, the LexV2 service handling the fulfillment response from the supervisory bot will return an error and the UI will display an error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
