### PR TITLE
Fix Austrian German neural voice name

### DIFF
--- a/lambda/lexv2-build/handler.py
+++ b/lambda/lexv2-build/handler.py
@@ -60,7 +60,7 @@ LEXV2_BOT_LOCALE_VOICES = {
         "engine": "standard"
     }],
     "de_AT": [{ #German (AT)
-        "voiceId": "Vicki",
+        "voiceId": "Hannah",
         "engine": "neural"
     }],
     "de_DE": [{ #German (DE)


### PR DESCRIPTION
*Issue #, if available:* #728

*Description of changes:* Change the voiceId for Austrian German to use the correct name from the list of available neural voice.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
