### PR TITLE
Adds a session attribute to count missed utterances

### DIFF
--- a/lambda/es-proxy-layer/lib/fulfillment-event/processFulfillmentEvent.js
+++ b/lambda/es-proxy-layer/lib/fulfillment-event/processFulfillmentEvent.js
@@ -226,6 +226,13 @@ async function processFulfillmentEvent(req, res) {
     res.session.qnabot_qid = _.get(res.result, 'qid', '');
     res.session.qnabot_gotanswer = res.got_hits > 0;
 
+    // add session attibute to count consecutive missed utterances
+    if (res.got_hits > 0) {
+        res.session.no_hits_counter = 0;
+    } else {
+        res.session.no_hits_counter = res.session.no_hits_counter ? res.session.no_hits_counter + 1 : 1;
+    }
+
     const event = { req, res };
     return event;
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds a session attribute that counts the number of consecutive missed utterances.  This information allows us to exhibit different behavior depending on how many times a user asks a question that the QnA Bot is unable to answer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
