### PR TITLE
Build exits with code 1, if a CF template is invalid

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -61,6 +61,7 @@ async function create(options) {
         log(`finished building ${stack}`, !options.silent);
     } catch (error) {
         log(chalk.red(`${stack} failed:${error}`), !options.silent);
+        process.exit(1)
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change exits the build process if a cloudformation template fails validation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
