### PR TITLE
Include aws-sdk-client-mock-jest as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -125,6 +125,7 @@
                 "@vue/test-utils": "^2.4.3",
                 "@vue/vue3-jest": "^29.2.6",
                 "aws-sdk-client-mock": "^3.0.0",
+                "aws-sdk-client-mock-jest": "^3.0.0",
                 "babel-loader": "^9.1.3",
                 "copy-webpack-plugin": "^11.0.0",
                 "css-loader": "^6.8.1",
@@ -5307,24 +5308,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/@jest/fake-timers/node_modules/@sinonjs/commons": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-            "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
-            "dev": true,
-            "dependencies": {
-                "type-detect": "4.0.8"
-            }
-        },
-        "node_modules/@jest/fake-timers/node_modules/@sinonjs/fake-timers": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-            "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
-            "dev": true,
-            "dependencies": {
-                "@sinonjs/commons": "^3.0.0"
-            }
-        },
         "node_modules/@jest/globals": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
@@ -5748,41 +5731,41 @@
             "dev": true
         },
         "node_modules/@sinonjs/commons": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-            "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+            "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
             "dev": true,
             "dependencies": {
                 "type-detect": "4.0.8"
             }
         },
         "node_modules/@sinonjs/fake-timers": {
-            "version": "9.1.2",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-            "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+            "version": "10.3.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+            "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
             "dev": true,
             "dependencies": {
-                "@sinonjs/commons": "^1.7.0"
-            }
-        },
-        "node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
-            "version": "1.8.6",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-            "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
-            "dev": true,
-            "dependencies": {
-                "type-detect": "4.0.8"
+                "@sinonjs/commons": "^3.0.0"
             }
         },
         "node_modules/@sinonjs/samsam": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
-            "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+            "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
             "dev": true,
             "dependencies": {
                 "@sinonjs/commons": "^2.0.0",
                 "lodash.get": "^4.4.2",
                 "type-detect": "^4.0.8"
+            }
+        },
+        "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+            "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+            "dev": true,
+            "dependencies": {
+                "type-detect": "4.0.8"
             }
         },
         "node_modules/@sinonjs/text-encoding": {
@@ -10362,15 +10345,34 @@
             }
         },
         "node_modules/aws-sdk-client-mock": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-3.0.0.tgz",
-            "integrity": "sha512-4mBiWhuLYLZe1+K/iB8eYy5SAZyW2se+Keyh5u9QouMt6/qJ5SRZhss68xvUX5g3ApzROJ06QPRziYHP6buuvQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-3.1.0.tgz",
+            "integrity": "sha512-3Mx5R8DDka2TB8qtr5jDbSVJsUM6uoX5tZSReBsJS8HunVtL9PHhb+RU7b+I3/53B2fJAyoEp7dJNXndBI+6MA==",
             "dev": true,
             "dependencies": {
                 "@types/sinon": "^10.0.10",
-                "sinon": "^14.0.2",
+                "sinon": "^16.1.3",
                 "tslib": "^2.1.0"
             }
+        },
+        "node_modules/aws-sdk-client-mock-jest": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk-client-mock-jest/-/aws-sdk-client-mock-jest-3.1.0.tgz",
+            "integrity": "sha512-pUuHS1xwzVvHadHmzZqOAxve4/RqcV0tta1mEqTcxrBOEenfy9BzhTWYcjdqQWyA5nphT2j6NM44DeSz9lD57A==",
+            "dev": true,
+            "dependencies": {
+                "expect": ">28.1.3",
+                "tslib": "^2.1.0"
+            },
+            "peerDependencies": {
+                "aws-sdk-client-mock": "3.1.0"
+            }
+        },
+        "node_modules/aws-sdk-client-mock-jest/node_modules/tslib": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+            "dev": true
         },
         "node_modules/aws-sdk-client-mock/node_modules/tslib": {
             "version": "2.6.2",
@@ -12915,9 +12917,9 @@
             "dev": true
         },
         "node_modules/diff": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-            "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
             "dev": true,
             "engines": {
                 "node": ">=0.3.1"
@@ -19107,9 +19109,9 @@
             }
         },
         "node_modules/just-extend": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-            "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+            "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
             "dev": true
         },
         "node_modules/jwa": {
@@ -20366,50 +20368,32 @@
             "dev": true
         },
         "node_modules/nise": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.5.tgz",
-            "integrity": "sha512-VJuPIfUFaXNRzETTQEEItTOP8Y171ijr+JLq42wHes3DiryR8vT+1TXQW/Rx8JNUhyYYWyIvjXTU6dOhJcs9Nw==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.9.tgz",
+            "integrity": "sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww==",
             "dev": true,
             "dependencies": {
-                "@sinonjs/commons": "^2.0.0",
-                "@sinonjs/fake-timers": "^10.0.2",
-                "@sinonjs/text-encoding": "^0.7.1",
-                "just-extend": "^4.0.2",
-                "path-to-regexp": "^1.7.0"
+                "@sinonjs/commons": "^3.0.0",
+                "@sinonjs/fake-timers": "^11.2.2",
+                "@sinonjs/text-encoding": "^0.7.2",
+                "just-extend": "^6.2.0",
+                "path-to-regexp": "^6.2.1"
             }
         },
         "node_modules/nise/node_modules/@sinonjs/fake-timers": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-            "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+            "version": "11.2.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+            "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
             "dev": true,
             "dependencies": {
                 "@sinonjs/commons": "^3.0.0"
             }
         },
-        "node_modules/nise/node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-            "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
-            "dev": true,
-            "dependencies": {
-                "type-detect": "4.0.8"
-            }
-        },
-        "node_modules/nise/node_modules/isarray": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-            "dev": true
-        },
         "node_modules/nise/node_modules/path-to-regexp": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-            "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-            "dev": true,
-            "dependencies": {
-                "isarray": "0.0.1"
-            }
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
+            "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+            "dev": true
         },
         "node_modules/no-case": {
             "version": "3.0.4",
@@ -23543,17 +23527,16 @@
             }
         },
         "node_modules/sinon": {
-            "version": "14.0.2",
-            "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.2.tgz",
-            "integrity": "sha512-PDpV0ZI3ZCS3pEqx0vpNp6kzPhHrLx72wA0G+ZLaaJjLIYeE0n8INlgaohKuGy7hP0as5tbUd23QWu5U233t+w==",
-            "deprecated": "16.1.1",
+            "version": "16.1.3",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-16.1.3.tgz",
+            "integrity": "sha512-mjnWWeyxcAf9nC0bXcPmiDut+oE8HYridTNzBbF98AYVLmWwGRp2ISEpyhYflG1ifILT+eNn3BmKUJPxjXUPlA==",
             "dev": true,
             "dependencies": {
-                "@sinonjs/commons": "^2.0.0",
-                "@sinonjs/fake-timers": "^9.1.2",
-                "@sinonjs/samsam": "^7.0.1",
-                "diff": "^5.0.0",
-                "nise": "^5.1.2",
+                "@sinonjs/commons": "^3.0.0",
+                "@sinonjs/fake-timers": "^10.3.0",
+                "@sinonjs/samsam": "^8.0.0",
+                "diff": "^5.1.0",
+                "nise": "^5.1.4",
                 "supports-color": "^7.2.0"
             },
             "funding": {

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
         "@vue/test-utils": "^2.4.3",
         "@vue/vue3-jest": "^29.2.6",
         "aws-sdk-client-mock": "^3.0.0",
+        "aws-sdk-client-mock-jest": "^3.0.0",
         "babel-loader": "^9.1.3",
         "copy-webpack-plugin": "^11.0.0",
         "css-loader": "^6.8.1",


### PR DESCRIPTION
This enables individual Jest test to be run, without running the entire test suite.

*Issue #, if available:* N/A

*Description of changes:* Include `aws-sdk-client-mock-jest` as a dependency in the development environment. This enables individual Jest tests to be run without running the entire suite.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
