### PR TITLE
Updated to version v7.0.0

### DIFF
--- a/source/package-lock.json
+++ b/source/package-lock.json
@@ -10927,7 +10927,7 @@
         },
         "node_modules/aws-lex-web-ui": {
             "version": "0.21.6",
-            "resolved": "git+ssh://git@github.com/aws-samples/aws-lex-web-ui.git#2a149c3e94f98bb550dbb023daca7a310038cb9c",
+            "resolved": "git+ssh://git@github.com/aws-samples/aws-lex-web-ui.git#61967a3d617116612423f46882ca6e7c2f89a1b9",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "amazon-cognito-auth-js": "^1.2.4",
@@ -11071,9 +11071,9 @@
             }
         },
         "node_modules/aws-lex-web-ui/node_modules/parse5": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.0.tgz",
-            "integrity": "sha512-ZkDsAOcxsUMZ4Lz5fVciOehNcJ+Gb8gTzcA4yl3wnc273BAybYWrQ+Ks/OjCjSEpjvQkDSeZbybK9qj2VHHdGA==",
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+            "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
             "license": "MIT",
             "dependencies": {
                 "entities": "^4.5.0"
@@ -12923,9 +12923,9 @@
             }
         },
         "node_modules/core-js": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
-            "integrity": "sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==",
+            "version": "3.40.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.40.0.tgz",
+            "integrity": "sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==",
             "hasInstallScript": true,
             "license": "MIT",
             "funding": {

--- a/source/templates/public-vpc-support/index.js
+++ b/source/templates/public-vpc-support/index.js
@@ -29,7 +29,9 @@ module.exports = Promise.resolve(require('../master')).then((base) => {
         'OpenSearchIndex',
         'MetricsBucket',
         'TestAllBucket',
-        'ContentDesignerOutputBucket'
+        'ContentDesignerOutputBucket',
+        'StreamingWebSocketEndpoint',
+        'SettingsTable'
     ]);
     base.Parameters = _.pick(base.Parameters, [
         'Email',

--- a/source/templates/public/index.js
+++ b/source/templates/public/index.js
@@ -29,7 +29,9 @@ module.exports = Promise.resolve(require('../master')).then((base) => {
         'OpenSearchIndex',
         'MetricsBucket',
         'TestAllBucket',
-        'ContentDesignerOutputBucket'
+        'ContentDesignerOutputBucket',
+        'StreamingWebSocketEndpoint',
+        'SettingsTable'
     ]);
     base.Parameters = _.pick(base.Parameters, [
         'Email',


### PR DESCRIPTION
## [7.0.0] - 2025-01-23

### Added
- Streaming responses feature that enhances QnABot responses by providing real-time streaming from Large Language Models (LLMs) to the chat interface. This introduces a cloudformation parameter `EnableStreaming` to optionally create resources needed for streaming through a nested stack. See [README](./source/docs/llm_streaming_responses/README.md). 
- Enhanced Guardrail Integration that implements pre-processing and post-processing guardrails to provide improved content control and broader security for your chatbot application. See [README](./source/docs/bedrock_guardrails/README.md). 
- Implemented Converse API to simplify LLM workflows by providing a consistent interface for different LLM providers, role prompting and eliminating the need for input tagging for Bedrock Guardrails. This introduces customizable system prompts `LLM_GENERATE_QUERY_SYSTEM_PROMPT` and `LLM_QA_SYSTEM_PROMPT` in content designer to support role-based prompting. For more information, see system prompts in [supported models and model features](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html) and [using Converse API](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-call.html).
- Ability to use both RAG with Bedrock KnowledgeBase and Kendra as fallback options. A new setting `FALLBACK_ORDER` in the content designer allows users to specify the fallback order of these options.
- Ability to set a TTL on records added to the DynamoDB UsersTable. ([PR #671](https://github.com/aws-solutions/qnabot-on-aws/pull/671)) - contributed by ([@richhaase](https://github.com/richhaase))
- Mistral as a new LLM provider option and support for [latest Anthropic Sonnet 3.5 V2, Haiku 3.5 V1, Amazon Nova Models, Ai21 Jambda Instruct, Cohere R plus and Meta Llama 3.1 models.](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html)

### Changed
- Upgraded to Node 20.
- Upgraded AWS SDK dependencies.
- Migrated Settings to DynamoDB store rather than SSM, allowing for longer custom settings and prompts.
- Moved Amazon Q Business Plugin from samples repo to QnABot repo as an example lambda hook
- Reduced the size of Bedrock KnowledgeBase output by removing citations from plaintext response.
- Updated OpenSearch EBSOptions VolumeType to `gp3` from `gp2`.
- Updated IAM permissions and cloudformation outputs.
- Added additional non-user input fields to OpenSearch metrics data redaction exclusion list.
- Migrated to Poetry for Python dependency management
- Updated innerHTML usages to innerText per security best practices

### Fixed
- Fixed issues with Excel file import and character handling when reading questions import file
- Improvements for merging of chained items ([PR #720](https://github.com/aws-solutions/qnabot-on-aws/pull/720)) - contributed by ([@amendlik](https://github.com/amendlik))

### Deprecated

- Settings stored in SSM Parameters. These will automatically be moved to DynamoDB when you upgrade.
- Sagemaker embeddings and LLM workflows.
- KendraCrawlerSNS Topic workflow [Issue #742](https://github.com/aws-solutions/qnabot-on-aws/issues/742)
- Bedrock LLM Models Cohere Command Text, Jurassic-2 Mid and Ultra per [Amazon Bedrock Model Lifefycle](https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html#versions-for-eol)

### Security
- Patched Jinja2, nanoid, path-to-regexp vulnerability